### PR TITLE
Add ChatMessage entity with repository and service layers

### DIFF
--- a/src/main/java/com/ahmed/chatmespringboot/chatmessages/ChatMessage.java
+++ b/src/main/java/com/ahmed/chatmespringboot/chatmessages/ChatMessage.java
@@ -1,0 +1,23 @@
+package com.ahmed.chatmespringboot.chatmessages;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Document
+public class ChatMessage {
+    @Id
+    private String id;
+    private String chatId;
+    private String senderId;
+    private String recipientId;
+    private String content;
+    private Date timestamp;
+}

--- a/src/main/java/com/ahmed/chatmespringboot/chatmessages/ChatMessageRepository.java
+++ b/src/main/java/com/ahmed/chatmespringboot/chatmessages/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package com.ahmed.chatmespringboot.chatmessages;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+
+    List<ChatMessage> findByChatId(String s);
+}

--- a/src/main/java/com/ahmed/chatmespringboot/chatmessages/ChatMessageService.java
+++ b/src/main/java/com/ahmed/chatmespringboot/chatmessages/ChatMessageService.java
@@ -1,0 +1,37 @@
+package com.ahmed.chatmespringboot.chatmessages;
+
+import com.ahmed.chatmespringboot.chatroom.ChatRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatMessageRepository repository;
+    private final ChatRoomService chatRoomService;
+
+    public ChatMessage save(ChatMessage chatMessage) {
+        var chatId = chatRoomService.getChatRoomId(
+                chatMessage.getSenderId(),
+                chatMessage.getRecipientId(),
+                true
+        ).orElseThrow();
+        chatMessage.setChatId(chatId);
+        repository.save(chatMessage);
+        return chatMessage;
+    }
+
+    public List<ChatMessage> findChatMessages(
+            String senderId, String recipientId
+    ) {
+        var chatId = chatRoomService.getChatRoomId(
+                senderId,
+                recipientId,
+                false);
+        return chatId.map(repository::findByChatId).orElse(new ArrayList<>());
+    }
+}


### PR DESCRIPTION
**This PR introduces the core components for handling chat messages:**

- `ChatMessage.java`: defines the entity structure for chat messages stored in MongoDB.
- `ChatMessageRepository.java`: provides data access methods using Spring Data MongoDB.
- `ChatMessageService.java`: contains business logic for saving and retrieving messages.

These components lay the foundation for the chat feature, including message storing and retrieval based on chat room ID.
